### PR TITLE
Fix: reapprove not working for some tokens

### DIFF
--- a/apps/create-vesting/src/hooks/useGetHooksInfoVestAllFromAccount.ts
+++ b/apps/create-vesting/src/hooks/useGetHooksInfoVestAllFromAccount.ts
@@ -36,27 +36,36 @@ export const useGetHooksInfoVestAllFromAccount = () => {
         args: [cowShedProxy, vestingEscrowFactoryAddress],
       });
 
-      const approveTxs =
-        allowance < maxUint256
-          ? [
-              TransactionFactory.createRawTx(TRANSACTION_TYPES.ERC20_APPROVE, {
-                type: TRANSACTION_TYPES.ERC20_APPROVE,
-                token: tokenAddress as Address,
-                spender: vestingEscrowFactoryAddress,
-                amount: BigInt(0),
-              }),
-              TransactionFactory.createRawTx(TRANSACTION_TYPES.ERC20_APPROVE, {
-                type: TRANSACTION_TYPES.ERC20_APPROVE,
-                token: tokenAddress as Address,
-                spender: vestingEscrowFactoryAddress,
-                amount: maxUint256,
-              }),
-            ]
-          : [];
+      const getApproveTxs = () => {
+        if (allowance === maxUint256) return [];
+        if (allowance === BigInt(0))
+          return [
+            TransactionFactory.createRawTx(TRANSACTION_TYPES.ERC20_APPROVE, {
+              type: TRANSACTION_TYPES.ERC20_APPROVE,
+              token: tokenAddress as Address,
+              spender: vestingEscrowFactoryAddress,
+              amount: maxUint256,
+            }),
+          ];
+        return [
+          TransactionFactory.createRawTx(TRANSACTION_TYPES.ERC20_APPROVE, {
+            type: TRANSACTION_TYPES.ERC20_APPROVE,
+            token: tokenAddress as Address,
+            spender: vestingEscrowFactoryAddress,
+            amount: BigInt(0),
+          }),
+          TransactionFactory.createRawTx(TRANSACTION_TYPES.ERC20_APPROVE, {
+            type: TRANSACTION_TYPES.ERC20_APPROVE,
+            token: tokenAddress as Address,
+            spender: vestingEscrowFactoryAddress,
+            amount: maxUint256,
+          }),
+        ];
+      };
 
       const txs = await Promise.all([
         // Approve create vesting
-        ...approveTxs,
+        ...getApproveTxs(),
         // transfer from user to proxy and create vesting (weiroll)
         TransactionFactory.createRawTx(
           TRANSACTION_TYPES.CREATE_VESTING_WEIROLL_USER,

--- a/apps/create-vesting/src/hooks/useGetHooksInfoVestAllFromAccount.ts
+++ b/apps/create-vesting/src/hooks/useGetHooksInfoVestAllFromAccount.ts
@@ -4,12 +4,12 @@ import {
   TransactionFactory,
 } from "@bleu/utils/transactionFactory";
 import { useCallback } from "react";
-import { type Address, maxUint256 } from "viem";
+import { type Address, erc20Abi, maxUint256 } from "viem";
 import { scaleToSecondsMapping } from "#/utils/scaleToSecondsMapping";
 import type { GetHooksTransactionsParams } from "./useGetHooksTransactions";
 
 export const useGetHooksInfoVestAllFromAccount = () => {
-  const { context, cowShedProxy } = useIFrameContext();
+  const { context, cowShedProxy, publicClient } = useIFrameContext();
 
   return useCallback(
     async (
@@ -21,7 +21,7 @@ export const useGetHooksInfoVestAllFromAccount = () => {
         formData: { period, periodScale, recipient },
       } = params;
 
-      if (!context?.account || !cowShedProxy) return;
+      if (!context?.account || !cowShedProxy || !publicClient) return;
 
       const periodInSeconds = Math.ceil(
         period * scaleToSecondsMapping[periodScale],
@@ -29,14 +29,34 @@ export const useGetHooksInfoVestAllFromAccount = () => {
       const tokenAddress = token.address as Address;
       const tokenSymbol = token.symbol ?? "";
 
+      const allowance = await publicClient.readContract({
+        address: tokenAddress,
+        abi: erc20Abi,
+        functionName: "allowance",
+        args: [cowShedProxy, vestingEscrowFactoryAddress],
+      });
+
+      const approveTxs =
+        allowance < maxUint256
+          ? [
+              TransactionFactory.createRawTx(TRANSACTION_TYPES.ERC20_APPROVE, {
+                type: TRANSACTION_TYPES.ERC20_APPROVE,
+                token: tokenAddress as Address,
+                spender: vestingEscrowFactoryAddress,
+                amount: BigInt(0),
+              }),
+              TransactionFactory.createRawTx(TRANSACTION_TYPES.ERC20_APPROVE, {
+                type: TRANSACTION_TYPES.ERC20_APPROVE,
+                token: tokenAddress as Address,
+                spender: vestingEscrowFactoryAddress,
+                amount: maxUint256,
+              }),
+            ]
+          : [];
+
       const txs = await Promise.all([
         // Approve create vesting
-        TransactionFactory.createRawTx(TRANSACTION_TYPES.ERC20_APPROVE, {
-          type: TRANSACTION_TYPES.ERC20_APPROVE,
-          token: tokenAddress,
-          spender: vestingEscrowFactoryAddress,
-          amount: maxUint256,
-        }),
+        ...approveTxs,
         // transfer from user to proxy and create vesting (weiroll)
         TransactionFactory.createRawTx(
           TRANSACTION_TYPES.CREATE_VESTING_WEIROLL_USER,
@@ -62,6 +82,6 @@ export const useGetHooksInfoVestAllFromAccount = () => {
 
       return { txs, permitData };
     },
-    [context?.account, cowShedProxy],
+    [context?.account, cowShedProxy, publicClient],
   );
 };

--- a/apps/create-vesting/src/hooks/useGetHooksInfoVestAllFromAccount.ts
+++ b/apps/create-vesting/src/hooks/useGetHooksInfoVestAllFromAccount.ts
@@ -37,7 +37,7 @@ export const useGetHooksInfoVestAllFromAccount = () => {
       });
 
       const getApproveTxs = () => {
-        if (allowance === maxUint256) return [];
+        if (allowance <= maxUint256 / BigInt(10)) return [];
         if (allowance === BigInt(0))
           return [
             TransactionFactory.createRawTx(TRANSACTION_TYPES.ERC20_APPROVE, {

--- a/apps/create-vesting/src/hooks/useGetHooksInfoVestAllFromSwap.ts
+++ b/apps/create-vesting/src/hooks/useGetHooksInfoVestAllFromSwap.ts
@@ -36,7 +36,7 @@ export const useGetHooksInfoVestAllFromSwap = () => {
       });
 
       const getApproveTxs = () => {
-        if (allowance === maxUint256) return [];
+        if (allowance <= maxUint256 / BigInt(10)) return [];
         if (allowance === BigInt(0))
           return [
             TransactionFactory.createRawTx(TRANSACTION_TYPES.ERC20_APPROVE, {

--- a/apps/create-vesting/src/hooks/useGetHooksInfoVestAllFromSwap.ts
+++ b/apps/create-vesting/src/hooks/useGetHooksInfoVestAllFromSwap.ts
@@ -35,27 +35,36 @@ export const useGetHooksInfoVestAllFromSwap = () => {
         args: [cowShedProxy, vestingEscrowFactoryAddress],
       });
 
-      const approveTxs =
-        allowance < maxUint256
-          ? [
-              TransactionFactory.createRawTx(TRANSACTION_TYPES.ERC20_APPROVE, {
-                type: TRANSACTION_TYPES.ERC20_APPROVE,
-                token: tokenAddress as Address,
-                spender: vestingEscrowFactoryAddress,
-                amount: BigInt(0),
-              }),
-              TransactionFactory.createRawTx(TRANSACTION_TYPES.ERC20_APPROVE, {
-                type: TRANSACTION_TYPES.ERC20_APPROVE,
-                token: tokenAddress as Address,
-                spender: vestingEscrowFactoryAddress,
-                amount: maxUint256,
-              }),
-            ]
-          : [];
+      const getApproveTxs = () => {
+        if (allowance === maxUint256) return [];
+        if (allowance === BigInt(0))
+          return [
+            TransactionFactory.createRawTx(TRANSACTION_TYPES.ERC20_APPROVE, {
+              type: TRANSACTION_TYPES.ERC20_APPROVE,
+              token: tokenAddress as Address,
+              spender: vestingEscrowFactoryAddress,
+              amount: maxUint256,
+            }),
+          ];
+        return [
+          TransactionFactory.createRawTx(TRANSACTION_TYPES.ERC20_APPROVE, {
+            type: TRANSACTION_TYPES.ERC20_APPROVE,
+            token: tokenAddress as Address,
+            spender: vestingEscrowFactoryAddress,
+            amount: BigInt(0),
+          }),
+          TransactionFactory.createRawTx(TRANSACTION_TYPES.ERC20_APPROVE, {
+            type: TRANSACTION_TYPES.ERC20_APPROVE,
+            token: tokenAddress as Address,
+            spender: vestingEscrowFactoryAddress,
+            amount: maxUint256,
+          }),
+        ];
+      };
 
       const txs = await Promise.all([
         // Proxy approves Vesting Escrow Factory
-        ...approveTxs,
+        ...getApproveTxs(),
         // Create vesting (weiroll)
         TransactionFactory.createRawTx(
           TRANSACTION_TYPES.CREATE_VESTING_WEIROLL_PROXY,

--- a/apps/deposit-cow-amm/src/hooks/useGetHookInfo.ts
+++ b/apps/deposit-cow-amm/src/hooks/useGetHookInfo.ts
@@ -154,7 +154,7 @@ export function useGetHookInfo(pool?: IPool) {
           if (
             allowances[idx].status === "failure" ||
             (BigInt(0) < BigInt(allowances[idx].result) &&
-              BigInt(allowances[idx].result) < MAX_UINT256)
+              BigInt(allowances[idx].result) < MAX_UINT256 / BigInt(10))
           )
             return [
               {

--- a/apps/deposit-cow-amm/src/hooks/useGetHookInfo.ts
+++ b/apps/deposit-cow-amm/src/hooks/useGetHookInfo.ts
@@ -153,7 +153,8 @@ export function useGetHookInfo(pool?: IPool) {
         .map((token, idx) => {
           if (
             allowances[idx].status === "failure" ||
-            BigInt(allowances[idx].result) < MAX_UINT256
+            (BigInt(0) < BigInt(allowances[idx].result) &&
+              BigInt(allowances[idx].result) < MAX_UINT256)
           )
             return [
               {
@@ -162,6 +163,16 @@ export function useGetHookInfo(pool?: IPool) {
                 spender: pool.address,
                 amount: BigInt(0),
               },
+              {
+                type: TRANSACTION_TYPES.ERC20_APPROVE,
+                token: token.address as Address,
+                spender: pool.address,
+                amount: MAX_UINT256,
+              },
+            ] as ERC20ApproveArgs[];
+
+          if (BigInt(0) === BigInt(allowances[idx].result))
+            return [
               {
                 type: TRANSACTION_TYPES.ERC20_APPROVE,
                 token: token.address as Address,

--- a/apps/deposit-uni-v2/src/hooks/useGetHookInfo.ts
+++ b/apps/deposit-uni-v2/src/hooks/useGetHookInfo.ts
@@ -160,7 +160,8 @@ export function useGetHookInfo(pool?: IPool) {
         .map((token, idx) => {
           if (
             allowances[idx].status === "failure" ||
-            BigInt(allowances[idx].result) < maxUint256
+            (BigInt(0) < BigInt(allowances[idx].result) &&
+              BigInt(allowances[idx].result) < maxUint256)
           )
             return [
               {
@@ -169,6 +170,16 @@ export function useGetHookInfo(pool?: IPool) {
                 spender: uniswapRouterAddress,
                 amount: BigInt(0),
               },
+              {
+                type: TRANSACTION_TYPES.ERC20_APPROVE,
+                token: token.address as Address,
+                spender: uniswapRouterAddress,
+                amount: maxUint256,
+              },
+            ] as ERC20ApproveArgs[];
+
+          if (BigInt(0) === BigInt(allowances[idx].result))
+            return [
               {
                 type: TRANSACTION_TYPES.ERC20_APPROVE,
                 token: token.address as Address,

--- a/apps/deposit-uni-v2/src/hooks/useGetHookInfo.ts
+++ b/apps/deposit-uni-v2/src/hooks/useGetHookInfo.ts
@@ -161,7 +161,7 @@ export function useGetHookInfo(pool?: IPool) {
           if (
             allowances[idx].status === "failure" ||
             (BigInt(0) < BigInt(allowances[idx].result) &&
-              BigInt(allowances[idx].result) < maxUint256)
+              BigInt(allowances[idx].result) < maxUint256 / BigInt(10))
           )
             return [
               {


### PR DESCRIPTION
CoW team reported an issue with USDT approve on Mainnet ([tenderly link](https://dashboard.tenderly.co/public/cow-protocol/hooks-store/simulator/6cd5a606-8aed-49a7-b9bc-2442a504c1b0/debugger?trace=0.2.2.4.3.2)). There are a few tokens, like USDT, that doesn't allow approvals if there are some amount already approved (to avoid the attacks described [here](https://docs.google.com/document/d/1YLPtQxZu1UAvO9cZ1O2RPXBbT0mooh4DYKjA_jp-RLM/)).

This fix reads the proxy balances before approval and perform two approvals (approve(0) and approve(maxUint256)) if there is already an approval different than maxUint256.

[example] Proxy calls before this fix:
1. approve Llamapay contract to spend maxUint256 token
2. create vesting using weiroll

[example] Proxy calls after this fix:

1- 
if LlamaPay contract allowance == maxUint256:
- do nothing

if LlamaPay contract allowance == 0:
- approve Llamapay contract to spend maxUint256 token

else:
- approve Llamapay contract to spend 0 token
- approve Llamapay contract to spend maxUint256 token

2- create vesting using weiroll

However, most of tokens doesn't have this check, so for those cases there will be one useless call. What do you think of this approach? Is it possible to avoid the extra approve(0) calls in those cases?

