### PR TITLE
Fix: reset maxUint256 approvals after hooks execution

### DIFF
--- a/apps/create-vesting/src/hooks/useGetHooksInfoVestAllFromAccount.ts
+++ b/apps/create-vesting/src/hooks/useGetHooksInfoVestAllFromAccount.ts
@@ -50,6 +50,13 @@ export const useGetHooksInfoVestAllFromAccount = () => {
             user: context.account,
           },
         ),
+        // Reset approvals
+        TransactionFactory.createRawTx(TRANSACTION_TYPES.ERC20_APPROVE, {
+          type: TRANSACTION_TYPES.ERC20_APPROVE,
+          token: tokenAddress,
+          spender: vestingEscrowFactoryAddress,
+          amount: BigInt(0),
+        }),
       ]);
 
       const permitData = [

--- a/apps/create-vesting/src/hooks/useGetHooksInfoVestAllFromSwap.ts
+++ b/apps/create-vesting/src/hooks/useGetHooksInfoVestAllFromSwap.ts
@@ -48,6 +48,13 @@ export const useGetHooksInfoVestAllFromSwap = () => {
             vestingEscrowFactoryAddress: vestingEscrowFactoryAddress,
           },
         ),
+        // Reset approvals
+        TransactionFactory.createRawTx(TRANSACTION_TYPES.ERC20_APPROVE, {
+          type: TRANSACTION_TYPES.ERC20_APPROVE,
+          token: tokenAddress,
+          spender: vestingEscrowFactoryAddress,
+          amount: BigInt(0),
+        }),
       ]);
 
       return { txs, recipientOverride: cowShedProxy };

--- a/apps/deposit-cow-amm/src/hooks/useGetHookInfo.ts
+++ b/apps/deposit-cow-amm/src/hooks/useGetHookInfo.ts
@@ -143,10 +143,22 @@ export function useGetHookInfo(pool?: IPool) {
         } as ERC20ApproveArgs;
       });
 
+      const resetApprovalsArgs = pool.poolTokens.map((token) => {
+        return {
+          type: TRANSACTION_TYPES.ERC20_APPROVE,
+          token: token.address as Address,
+          spender: pool.address,
+          amount: BigInt(0),
+        } as ERC20ApproveArgs;
+      });
+
       return Promise.all(
-        [...transferFromUserToProxyArgs, ...approveArgs, depositArg].map(
-          (arg) => TransactionFactory.createRawTx(arg.type, arg),
-        ),
+        [
+          ...transferFromUserToProxyArgs,
+          ...approveArgs,
+          depositArg,
+          ...resetApprovalsArgs,
+        ].map((arg) => TransactionFactory.createRawTx(arg.type, arg)),
       );
     },
     [context, cowShedProxy, pool],

--- a/apps/deposit-cow-amm/src/hooks/useGetHookInfo.ts
+++ b/apps/deposit-cow-amm/src/hooks/useGetHookInfo.ts
@@ -54,7 +54,7 @@ export function useGetHookInfo(pool?: IPool) {
         const tokenAddress = token.address.toLowerCase();
         const amount = params.amounts[tokenAddress];
         const amountBigNumber = BigNumber.from(
-          parseUnits(amount.toString(), token.decimals)
+          parseUnits(amount.toString(), token.decimals),
         );
         return {
           tokenAddress,
@@ -81,7 +81,7 @@ export function useGetHookInfo(pool?: IPool) {
           }) || []
       );
     },
-    [pool, tokenAllowances, defaultPermitData]
+    [pool, tokenAllowances, defaultPermitData],
   );
 
   const getPoolDepositTxs = useCallback(
@@ -99,7 +99,7 @@ export function useGetHookInfo(pool?: IPool) {
       const referenceTokenDecimals = pool.poolTokens.find(
         (token) =>
           token.address.toLowerCase() ===
-          params.referenceTokenAddress.toLowerCase()
+          params.referenceTokenAddress.toLowerCase(),
       )?.decimals;
 
       if (!referenceTokenDecimals) throw new Error("Invalid reference token");
@@ -112,7 +112,7 @@ export function useGetHookInfo(pool?: IPool) {
             params.amounts[
               params.referenceTokenAddress.toLowerCase()
             ].toString(),
-            referenceTokenDecimals
+            referenceTokenDecimals,
           ),
           decimals: referenceTokenDecimals,
           address: params.referenceTokenAddress as Address,
@@ -200,10 +200,10 @@ export function useGetHookInfo(pool?: IPool) {
           ...approveArgs,
           depositArg,
           ...resetApprovalsArgs,
-        ].map((arg) => TransactionFactory.createRawTx(arg.type, arg))
+        ].map((arg) => TransactionFactory.createRawTx(arg.type, arg)),
       );
     },
-    [context, cowShedProxy, pool, publicClient]
+    [context, cowShedProxy, pool, publicClient],
   );
 
   const getWeirollTransferFromProxyToUserTxs = useCallback(() => {
@@ -219,7 +219,7 @@ export function useGetHookInfo(pool?: IPool) {
     } as ERC20TransferFromAllWeirollArgs;
     return TransactionFactory.createRawTx(
       weirollTransferFromProxyArgs.type,
-      weirollTransferFromProxyArgs
+      weirollTransferFromProxyArgs,
     );
   }, [context?.account, cowShedProxy, pool]);
 
@@ -236,6 +236,6 @@ export function useGetHookInfo(pool?: IPool) {
         txs: [...poolDepositTxs, transferTx],
       };
     },
-    [getPermitData, getPoolDepositTxs, getWeirollTransferFromProxyToUserTxs]
+    [getPermitData, getPoolDepositTxs, getWeirollTransferFromProxyToUserTxs],
   );
 }

--- a/apps/deposit-uni-v2/src/hooks/useGetHookInfo.ts
+++ b/apps/deposit-uni-v2/src/hooks/useGetHookInfo.ts
@@ -155,10 +155,22 @@ export function useGetHookInfo(pool?: IPool) {
         } as ERC20ApproveArgs;
       });
 
+      const resetApprovalsArgs = pool.poolTokens.map((token) => {
+        return {
+          type: TRANSACTION_TYPES.ERC20_APPROVE,
+          token: token.address as Address,
+          spender: uniswapRouterAddress,
+          amount: BigInt(0),
+        } as ERC20ApproveArgs;
+      });
+
       return Promise.all(
-        [...transferFromUserToProxyArgs, ...approveArgs, depositArg].map(
-          (arg) => TransactionFactory.createRawTx(arg.type, arg),
-        ),
+        [
+          ...transferFromUserToProxyArgs,
+          ...approveArgs,
+          depositArg,
+          ...resetApprovalsArgs,
+        ].map((arg) => TransactionFactory.createRawTx(arg.type, arg)),
       );
     },
     [context, cowShedProxy, pool, uniswapRouterAddress, deadline],

--- a/apps/deposit-uni-v2/src/hooks/useGetHookInfo.ts
+++ b/apps/deposit-uni-v2/src/hooks/useGetHookInfo.ts
@@ -53,7 +53,7 @@ export function useGetHookInfo(pool?: IPool) {
         const tokenAddress = token.address.toLowerCase();
         const amount = params.amounts[tokenAddress];
         const amountBigNumber = BigNumber.from(
-          parseUnits(amount.toString(), token.decimals)
+          parseUnits(amount.toString(), token.decimals),
         );
         return {
           tokenAddress,
@@ -80,7 +80,7 @@ export function useGetHookInfo(pool?: IPool) {
           }) || []
       );
     },
-    [pool, tokenAllowances, defaultPermitData]
+    [pool, tokenAllowances, defaultPermitData],
   );
 
   const getPoolDepositTxs = useCallback(
@@ -98,7 +98,7 @@ export function useGetHookInfo(pool?: IPool) {
       const referenceTokenDecimals = pool.poolTokens.find(
         (token) =>
           token.address.toLowerCase() ===
-          params.referenceTokenAddress.toLowerCase()
+          params.referenceTokenAddress.toLowerCase(),
       )?.decimals;
 
       if (!referenceTokenDecimals) throw new Error("Invalid reference token");
@@ -108,11 +108,11 @@ export function useGetHookInfo(pool?: IPool) {
 
       const desiredAmountA = parseUnits(
         params.amounts[tokenA.address.toLowerCase()],
-        tokenA.decimals
+        tokenA.decimals,
       );
       const desiredAmountB = parseUnits(
         params.amounts[tokenB.address.toLowerCase()],
-        tokenB.decimals
+        tokenB.decimals,
       );
 
       const amountAMin =
@@ -207,10 +207,10 @@ export function useGetHookInfo(pool?: IPool) {
           ...approveArgs,
           depositArg,
           ...resetApprovalsArgs,
-        ].map((arg) => TransactionFactory.createRawTx(arg.type, arg))
+        ].map((arg) => TransactionFactory.createRawTx(arg.type, arg)),
       );
     },
-    [context, cowShedProxy, pool, uniswapRouterAddress, deadline, publicClient]
+    [context, cowShedProxy, pool, uniswapRouterAddress, deadline, publicClient],
   );
 
   return useCallback(
@@ -225,6 +225,6 @@ export function useGetHookInfo(pool?: IPool) {
         txs: poolDepositTxs,
       };
     },
-    [getPermitData, getPoolDepositTxs]
+    [getPermitData, getPoolDepositTxs],
   );
 }


### PR DESCRIPTION
Some hooks need to approve maxUint256 amount of tokens, once the really amount to be used during the hook is unknown (i.e. in weiroll cases). The problem is that after the hook execution, the interacted contract would still have rights to transfer almost maxUint256 tokens (maxUint256 - amount used on hook), which can be dangerous.

This fix resets the approvals to 0 after those hooks execution

[example] Proxy calls before this fix:
1. approve Llamapay contract to spend maxUint256 token
2. create vesting using weiroll

[example] Proxy calls after this fix:
1. approve Llamapay contract to spend maxUint256 token
2. create vesting using weiroll
3. approve Llamapay contract to spend 0 token