### PR TITLE
fix: duplicated balances diffs on uni-v2 and cow-amm deposits

### DIFF
--- a/packages/cow-hooks-ui/src/hooks/useFormatTokenAmount.ts
+++ b/packages/cow-hooks-ui/src/hooks/useFormatTokenAmount.ts
@@ -1,0 +1,27 @@
+import { formatNumber } from "@bleu.builders/ui";
+import { useMemo } from "react";
+
+export const useFormatTokenAmount = ({
+  amount,
+  decimals,
+}: {
+  amount: bigint | undefined;
+  decimals: number | undefined;
+}) => {
+  const float = useMemo(
+    () =>
+      amount !== undefined && decimals !== undefined
+        ? Number(amount) / 10 ** Number(decimals)
+        : undefined,
+    [amount, decimals],
+  );
+
+  const formatted = useMemo(
+    () =>
+      float !== undefined
+        ? formatNumber(float, 4, "decimal", "standard", 0.0001)
+        : "",
+    [float],
+  );
+  return { float, formatted };
+};

--- a/packages/cow-hooks-ui/src/hooks/useTokenBalanceAfterSwap.ts
+++ b/packages/cow-hooks-ui/src/hooks/useTokenBalanceAfterSwap.ts
@@ -1,30 +1,15 @@
-import { useMemo } from "react";
-import { type Address, formatUnits } from "viem";
-import { useIFrameContext } from "../context";
-import { updateTokenBalanceAfterSwap } from "../utils/math";
+import type { Address } from "viem";
+import { useFormatTokenAmount } from "./useFormatTokenAmount";
 import { useReadTokenContract } from "./useReadTokenContract";
-import { useSwapAmount } from "./useSwapAmount";
 
 export function useTokenBalanceAfterSwap(address: string) {
-  const { context } = useIFrameContext();
-  const { sellAmount, buyAmount } = useSwapAmount();
   const { tokenDecimals, userBalance } = useReadTokenContract({
     tokenAddress: address as Address | undefined,
   });
+  const { formatted } = useFormatTokenAmount({
+    amount: userBalance,
+    decimals: tokenDecimals,
+  });
 
-  return useMemo(() => {
-    if (!buyAmount || !tokenDecimals) return;
-    return updateTokenBalanceAfterSwap({
-      userBalance: formatUnits(
-        userBalance || BigInt(0),
-        tokenDecimals,
-      ) as `${number}`,
-      tokenAddress: address as Address,
-      tokenDecimals: tokenDecimals,
-      sellAmount: sellAmount as `${number}`,
-      buyAmount: buyAmount as `${number}`,
-      tokenBuyAddress: context?.orderParams?.buyTokenAddress as Address,
-      tokenSellAddress: context?.orderParams?.sellTokenAddress as Address,
-    });
-  }, [buyAmount, sellAmount, tokenDecimals, userBalance, context, address]);
+  return formatted;
 }

--- a/packages/cow-hooks-ui/src/hooks/useTokensAfterSwap.ts
+++ b/packages/cow-hooks-ui/src/hooks/useTokensAfterSwap.ts
@@ -1,47 +1,75 @@
 import { useMemo } from "react";
-import type { Address } from "viem";
-import { useIFrameContext } from "../context";
-import { updateTokenBalanceAfterSwap } from "../utils/math";
-import { useSwapAmount } from "./useSwapAmount";
+import { type Address, formatUnits } from "viem";
+import { useReadTokenContract } from "./useReadTokenContract";
 import { useTokens } from "./useTokens";
 
 export function useTokensAfterSwap(
   tokens: Address[],
 ): Record<string, { balance: `${number}`; decimals: number; symbol: string }> {
-  const { context } = useIFrameContext();
   const balancesBeforeSwap = useTokens(tokens);
-  const { buyAmount, sellAmount } = useSwapAmount();
+
+  const token0 = tokens.length > 0 ? tokens[0] : undefined;
+  const token1 = tokens.length > 1 ? tokens[1] : undefined;
+
+  const {
+    userBalance: balance0,
+    tokenSymbol: symbol0,
+    tokenDecimals: decimals0,
+  } = useReadTokenContract({ tokenAddress: token0 });
+  const {
+    userBalance: balance1,
+    tokenSymbol: symbol1,
+    tokenDecimals: decimals1,
+  } = useReadTokenContract({ tokenAddress: token1 });
+
+  const floatBalance0 = useMemo(
+    () =>
+      balance0 && decimals0 ? formatUnits(balance0, decimals0) : undefined,
+    [balance0, decimals0],
+  );
+  const floatBalance1 = useMemo(
+    () =>
+      balance1 && decimals1 ? formatUnits(balance1, decimals1) : undefined,
+    [balance1, decimals1],
+  );
+
   return useMemo(() => {
-    if (!buyAmount || !sellAmount || !context?.orderParams)
+    if (
+      !token0 ||
+      !token1 ||
+      !floatBalance0 ||
+      !floatBalance1 ||
+      !symbol0 ||
+      !symbol1 ||
+      !decimals0 ||
+      !decimals1
+    )
       return balancesBeforeSwap;
 
-    return Object.keys(balancesBeforeSwap || {}).reduce(
-      (acc, token, _index) => {
-        const tokenBalance = balancesBeforeSwap[token];
-        if (!tokenBalance) return acc;
-        return {
-          // biome-ignore lint:
-          ...acc,
-          [token]: {
-            balance: updateTokenBalanceAfterSwap({
-              userBalance: balancesBeforeSwap[token].balance,
-              tokenAddress: token as Address,
-              tokenDecimals: balancesBeforeSwap[token].decimals,
-              tokenBuyAddress: context.orderParams?.buyTokenAddress as Address,
-              tokenSellAddress: context.orderParams
-                ?.sellTokenAddress as Address,
-              sellAmount,
-              buyAmount,
-            }),
-            decimals: balancesBeforeSwap[token].decimals,
-            symbol: balancesBeforeSwap[token].symbol,
-          },
-        };
+    return {
+      [token0]: {
+        balance: floatBalance0,
+        decimals: decimals0,
+        symbol: symbol0,
       },
-      {} as Record<
-        string,
-        { balance: `${number}`; decimals: number; symbol: string }
-      >,
-    );
-  }, [balancesBeforeSwap, buyAmount, sellAmount, context?.orderParams]);
+      [token1]: {
+        balance: floatBalance1,
+        decimals: decimals1,
+        symbol: symbol1,
+      },
+    } as Record<
+      string,
+      { balance: `${number}`; decimals: number; symbol: string }
+    >;
+  }, [
+    token0,
+    token1,
+    floatBalance0,
+    floatBalance1,
+    symbol0,
+    symbol1,
+    decimals0,
+    decimals1,
+    balancesBeforeSwap,
+  ]);
 }


### PR DESCRIPTION
Context: After we fixed useReadTokenContract to take balancesDiff in account correctly, the uni-v2 and cow-amm deposits started to compute balancesDiff twice, once they were prepared to read the tokens without balances diff. Image below is an example of what was happening:

![image](https://github.com/user-attachments/assets/5d1cc946-2383-4f54-b98a-8e1440d6466b)


This PR applies useReadTokensContract as a standard for all of them