### PR TITLE
Handle supply borrow fields logic

### DIFF
--- a/apps/morpho-supply/src/components/AmoutIntput.tsx
+++ b/apps/morpho-supply/src/components/AmoutIntput.tsx
@@ -1,10 +1,19 @@
-import { TokenAmountInput } from "@bleu/cow-hooks-ui";
+import { Input, Label, cn } from "@bleu.builders/ui";
+import { InfoTooltip, TokenLogo } from "@bleu/cow-hooks-ui";
 import { Token } from "@uniswap/sdk-core";
+import {
+  type FieldError,
+  useFormContext,
+  useFormState,
+  useWatch,
+} from "react-hook-form";
 import type { Address } from "viem";
+import type { MorphoSupplyFormData } from "#/contexts/form";
 
 interface AmountInputProps {
-  name: string;
+  name: "supplyAmount" | "borrowAmount";
   label: string;
+  maxName: "isMaxSupply" | "isMaxBorrow";
   asset: {
     address: Address;
     decimals: number;
@@ -22,12 +31,24 @@ interface AmountInputProps {
 export const AmountInput = ({
   name,
   label,
+  maxName,
   asset,
   chainId,
   formattedBalance,
   floatBalance,
   fiatBalance,
 }: AmountInputProps) => {
+  const { register, control, setValue } =
+    useFormContext<MorphoSupplyFormData>();
+
+  const { errors } = useFormState({ control });
+  const values = useWatch({ control });
+
+  const isMaxValue = values[maxName] as boolean;
+
+  const error = errors[name] as FieldError | undefined;
+  const errorMessage = error?.message;
+
   const handleSetValue = (value: string) => {
     if (value === "") return undefined;
     if (typeof value === "number") return value;
@@ -40,26 +61,90 @@ export const AmountInput = ({
     return Number(v);
   };
 
+  const tooltipText = undefined;
+  const tooltipLink = undefined;
+  const extraLabelElement = undefined;
+
+  const token = new Token(chainId, asset.address, asset.decimals, asset.symbol);
+
+  const userBalance = formattedBalance;
+  const userBalanceFullDecimals = String(floatBalance);
+  const fiatAmount = fiatBalance;
+
+  const className = "";
+  const validation = { setValueAs: handleSetValue };
+
   return (
-    <TokenAmountInput
-      name={name}
-      type="number"
-      inputMode="decimal"
-      step={`0.${"0".repeat(asset.decimals - 1)}1`}
-      max="1000000000000"
-      token={new Token(chainId, asset.address, asset.decimals, asset.symbol)}
-      label={label}
-      placeholder="0.0"
-      autoComplete="off"
-      disabled={false}
-      userBalance={formattedBalance}
-      userBalanceFullDecimals={String(floatBalance)}
-      fiatAmount={fiatBalance}
-      shouldEnableMaxSelector={true}
-      validation={{ setValueAs: handleSetValue }}
-      onKeyDown={(e) =>
-        ["e", "E", "+", "-"].includes(e.key) && e.preventDefault()
-      }
-    />
+    <div className="w-full">
+      {label && (
+        <div className="flex flex-row gap-x-2 items-center mb-2">
+          <Label className="ml-2 block text-sm">{label}</Label>
+          {tooltipText && <InfoTooltip text={tooltipText} link={tooltipLink} />}
+          {extraLabelElement}
+        </div>
+      )}
+      <div className="flex flex-col gap-1 w-full min-h-24 pt-4 pb-1 px-6 bg-color-paper-darker rounded-xl items-start">
+        <div className="flex w-full items-center justify-between gap-2">
+          <div className="rounded-xl text-color-text-paper bg-color-paper cursor-default">
+            {token && (
+              <div className="w-fit py-2 px-4 flex items-center justify-center gap-2">
+                <div className="w-6 h-6">
+                  <TokenLogo token={token} height={24} width={24} alt="" />
+                </div>
+                <span className="m-0 p-0 min-h-fit">{token?.symbol}</span>
+              </div>
+            )}
+          </div>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={`0.${"0".repeat(asset.decimals - 1)}1`}
+            max="1000000000000"
+            placeholder="0.0"
+            autoComplete="off"
+            className={cn(
+              "outline-none font-semibold text-xl text-color-text-paper bg-inherit placeholder:opacity-70 text-right p-0 m-0 h-min border-none rounded-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none truncate",
+              className,
+            )}
+            onKeyDown={(e) =>
+              ["e", "E", "+", "-"].includes(e.key) && e.preventDefault()
+            }
+            {...register(name, validation)}
+          />
+        </div>
+        <div className="flex w-full justify-between items-center">
+          {userBalance && token?.symbol && (
+            <span className="font-normal pl-1">
+              <span
+                title={userBalanceFullDecimals}
+                className="opacity-40 text-xs"
+              >
+                Max: {userBalance} {token?.symbol}
+              </span>
+              <button
+                type="button"
+                className={cn(
+                  "inline text-color-text-paper bg-color-paper px-1 ml-1 opacity-100 rounded-md text-xs hover:bg-color-primary hover:text-color-button-text transition-all duration-[200ms] ease-in-out [outline:none]",
+                  {
+                    "bg-color-primary text-color-button-text": isMaxValue,
+                  },
+                )}
+                onClick={() => setValue(maxName, !isMaxValue)}
+              >
+                MAX
+              </button>
+            </span>
+          )}
+          <span title={userBalanceFullDecimals} className="opacity-40 text-xs">
+            {fiatAmount}
+          </span>
+        </div>
+      </div>
+      {errorMessage && (
+        <div className="mt-1 ml-2 text-start text-sm text-destructive">
+          {errorMessage}
+        </div>
+      )}
+    </div>
   );
 };

--- a/apps/morpho-supply/src/components/AmoutIntput.tsx
+++ b/apps/morpho-supply/src/components/AmoutIntput.tsx
@@ -1,5 +1,5 @@
 import { Input, Label, cn } from "@bleu.builders/ui";
-import { InfoTooltip, TokenLogo } from "@bleu/cow-hooks-ui";
+import { TokenLogo } from "@bleu/cow-hooks-ui";
 import { Token } from "@uniswap/sdk-core";
 import {
   type FieldError,
@@ -24,7 +24,7 @@ interface AmountInputProps {
   };
   chainId: number;
   formattedBalance: string;
-  floatBalance: number;
+  floatBalance: string;
   fiatBalance: string;
 }
 
@@ -61,26 +61,21 @@ export const AmountInput = ({
     return Number(v);
   };
 
-  const tooltipText = undefined;
-  const tooltipLink = undefined;
-  const extraLabelElement = undefined;
+  const handleDisableMaxOnUserInput = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    if (isMaxValue && e.isTrusted) {
+      setValue(maxName, false);
+    }
+  };
 
   const token = new Token(chainId, asset.address, asset.decimals, asset.symbol);
-
-  const userBalance = formattedBalance;
-  const userBalanceFullDecimals = String(floatBalance);
-  const fiatAmount = fiatBalance;
-
-  const className = "";
-  const validation = { setValueAs: handleSetValue };
 
   return (
     <div className="w-full">
       {label && (
         <div className="flex flex-row gap-x-2 items-center mb-2">
           <Label className="ml-2 block text-sm">{label}</Label>
-          {tooltipText && <InfoTooltip text={tooltipText} link={tooltipLink} />}
-          {extraLabelElement}
         </div>
       )}
       <div className="flex flex-col gap-1 w-full min-h-24 pt-4 pb-1 px-6 bg-color-paper-darker rounded-xl items-start">
@@ -102,24 +97,21 @@ export const AmountInput = ({
             max="1000000000000"
             placeholder="0.0"
             autoComplete="off"
-            className={cn(
-              "outline-none font-semibold text-xl text-color-text-paper bg-inherit placeholder:opacity-70 text-right p-0 m-0 h-min border-none rounded-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none truncate",
-              className,
-            )}
+            className="outline-none font-semibold text-xl text-color-text-paper bg-inherit placeholder:opacity-70 text-right p-0 m-0 h-min border-none rounded-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none truncate"
             onKeyDown={(e) =>
               ["e", "E", "+", "-"].includes(e.key) && e.preventDefault()
             }
-            {...register(name, validation)}
+            {...register(name, {
+              setValueAs: handleSetValue,
+              onChange: handleDisableMaxOnUserInput,
+            })}
           />
         </div>
         <div className="flex w-full justify-between items-center">
-          {userBalance && token?.symbol && (
+          {formattedBalance && token?.symbol && (
             <span className="font-normal pl-1">
-              <span
-                title={userBalanceFullDecimals}
-                className="opacity-40 text-xs"
-              >
-                Max: {userBalance} {token?.symbol}
+              <span title={floatBalance} className="opacity-40 text-xs">
+                Max: {formattedBalance} {token?.symbol}
               </span>
               <button
                 type="button"
@@ -135,8 +127,8 @@ export const AmountInput = ({
               </button>
             </span>
           )}
-          <span title={userBalanceFullDecimals} className="opacity-40 text-xs">
-            {fiatAmount}
+          <span title={floatBalance} className="opacity-40 text-xs">
+            {fiatBalance}
           </span>
         </div>
       </div>

--- a/apps/morpho-supply/src/components/MarketForm.tsx
+++ b/apps/morpho-supply/src/components/MarketForm.tsx
@@ -15,9 +15,9 @@ import { useDynamicBorrow } from "#/hooks/useDynamicBorrow";
 import { useFormatTokenAmount } from "#/hooks/useFormatTokenAmount";
 import { useMaxBorrowableAmount } from "#/hooks/useMaxBorrowableAmount";
 import { useUserMarketPosition } from "#/hooks/useUserMarketPosition";
+import { decimalsToBigInt } from "#/utils/decimalsToBigInt";
 import { getMarketParams } from "#/utils/getMarketParams";
 import { AmountInput } from "./AmoutIntput";
-import { decimalsToBigInt } from "#/utils/decimalsToBigInt";
 
 export function MarketForm({ market }: { market: MorphoMarket }) {
   const { context } = useIFrameContext();
@@ -158,27 +158,27 @@ export function MarketForm({ market }: { market: MorphoMarket }) {
   const lltv = formatNumber(
     Number(market.lltv.toString().slice(0, 3)) / 1000,
     1,
-    "percent"
+    "percent",
   );
 
   const supplyAmountBigInt = decimalsToBigInt(
     supplyAmount,
-    market.collateralAsset.decimals
+    market.collateralAsset.decimals,
   );
   const isInsufficientBalance = Boolean(
     collateral !== undefined &&
       supplyAmountBigInt !== undefined &&
-      supplyAmountBigInt > collateral
+      supplyAmountBigInt > collateral,
   );
 
   const borrowAmountBigInt = decimalsToBigInt(
     borrowAmount,
-    market.loanAsset.decimals
+    market.loanAsset.decimals,
   );
   const isInsufficientPosition = Boolean(
     maxBorrowableAmount !== undefined &&
       borrowAmountBigInt !== undefined &&
-      borrowAmountBigInt > maxBorrowableAmount
+      borrowAmountBigInt > maxBorrowableAmount,
   );
 
   const buttonMessage = useMemo(() => {

--- a/apps/morpho-supply/src/components/MarketForm.tsx
+++ b/apps/morpho-supply/src/components/MarketForm.tsx
@@ -187,6 +187,7 @@ export function MarketForm({ market }: { market: MorphoMarket }) {
       <AmountInput
         name="supplyAmount"
         label="Supply Collateral"
+        maxName="isMaxSupply"
         asset={market.collateralAsset}
         chainId={market.oracle.chain.id}
         formattedBalance={formattedCollateralBalance}
@@ -196,6 +197,7 @@ export function MarketForm({ market }: { market: MorphoMarket }) {
       <AmountInput
         name="borrowAmount"
         label={`Borrow ${market.loanAsset.symbol}`}
+        maxName="isMaxBorrow"
         asset={market.loanAsset}
         chainId={market.oracle.chain.id}
         formattedBalance={formattedLoanBalance}

--- a/apps/morpho-supply/src/components/MarketForm.tsx
+++ b/apps/morpho-supply/src/components/MarketForm.tsx
@@ -16,6 +16,7 @@ import { useFormatTokenAmount } from "#/hooks/useFormatTokenAmount";
 import { useUserMarketPosition } from "#/hooks/useUserMarketPosition";
 import { getMarketParams } from "#/utils/getMarketParams";
 import { AmountInput } from "./AmoutIntput";
+import { useMaxBorrowableAmount } from "#/hooks/useMaxBorrowableAmount";
 
 export function MarketForm({ market }: { market: MorphoMarket }) {
   const { context } = useIFrameContext();
@@ -99,6 +100,8 @@ export function MarketForm({ market }: { market: MorphoMarket }) {
     if (!context?.hookToEdit && !context?.isPreHook)
       return <span>Add Post-hook</span>;
   }, [context?.hookToEdit, context?.isPreHook]);
+
+  const maxBorrowableAmount = useMaxBorrowableAmount();
 
   if (!context) return null;
 

--- a/apps/morpho-supply/src/contexts/form.tsx
+++ b/apps/morpho-supply/src/contexts/form.tsx
@@ -12,11 +12,15 @@ export interface MorphoSupplyFormData {
   market: MorphoMarket;
   supplyAmount: string;
   borrowAmount: string;
+  isMaxSupply: boolean;
+  isMaxBorrow: boolean;
 }
 
 export function FormContextProvider({ children }: PropsWithChildren) {
   const { setHookInfo } = useIFrameContext();
-  const form = useForm<MorphoSupplyFormData>({});
+  const form = useForm<MorphoSupplyFormData>({
+    defaultValues: { isMaxBorrow: false, isMaxSupply: false },
+  });
 
   const router = useRouter();
 

--- a/apps/morpho-supply/src/hooks/useFormatTokenAmount.ts
+++ b/apps/morpho-supply/src/hooks/useFormatTokenAmount.ts
@@ -1,27 +1,44 @@
 import { formatNumber } from "@bleu.builders/ui";
 import { useMemo } from "react";
+import { formatUnits } from "viem";
 
 export const useFormatTokenAmount = ({
   amount,
   decimals,
+  priceUsd,
 }: {
   amount: bigint | undefined;
   decimals: number | undefined;
+  priceUsd?: number;
 }) => {
-  const float = useMemo(
+  const fullDecimals = useMemo(
     () =>
       amount !== undefined && decimals !== undefined
-        ? Number(amount) / 10 ** Number(decimals)
-        : undefined,
-    [amount, decimals],
+        ? formatUnits(amount, decimals)
+        : "",
+    [amount, decimals]
   );
 
   const formatted = useMemo(
     () =>
-      float !== undefined
-        ? formatNumber(float, 4, "decimal", "standard", 0.0001)
+      fullDecimals !== undefined
+        ? formatNumber(fullDecimals, 4, "decimal", "compact", 0.0001)
         : "",
-    [float],
+    [fullDecimals]
   );
-  return { float, formatted };
+
+  const usd = useMemo(
+    () =>
+      fullDecimals && priceUsd !== undefined
+        ? Number(fullDecimals) * priceUsd
+        : undefined,
+    [fullDecimals, priceUsd]
+  );
+
+  const usdFormatted = useMemo(
+    () => (usd !== undefined ? `≈ $${formatNumber(usd, 2, "decimal")}` : ""),
+    [usd]
+  );
+
+  return { formatted, fullDecimals, usd, usdFormatted };
 };

--- a/apps/morpho-supply/src/hooks/useFormatTokenAmount.ts
+++ b/apps/morpho-supply/src/hooks/useFormatTokenAmount.ts
@@ -16,7 +16,7 @@ export const useFormatTokenAmount = ({
       amount !== undefined && decimals !== undefined
         ? formatUnits(amount, decimals)
         : "",
-    [amount, decimals]
+    [amount, decimals],
   );
 
   const formatted = useMemo(
@@ -24,7 +24,7 @@ export const useFormatTokenAmount = ({
       fullDecimals !== undefined
         ? formatNumber(fullDecimals, 4, "decimal", "compact", 0.0001)
         : "",
-    [fullDecimals]
+    [fullDecimals],
   );
 
   const usd = useMemo(
@@ -32,12 +32,12 @@ export const useFormatTokenAmount = ({
       fullDecimals && priceUsd !== undefined
         ? Number(fullDecimals) * priceUsd
         : undefined,
-    [fullDecimals, priceUsd]
+    [fullDecimals, priceUsd],
   );
 
   const usdFormatted = useMemo(
     () => (usd !== undefined ? `≈ $${formatNumber(usd, 2, "decimal")}` : ""),
-    [usd]
+    [usd],
   );
 
   return { formatted, fullDecimals, usd, usdFormatted };

--- a/apps/morpho-supply/src/hooks/useMaxBorrowableAmount.ts
+++ b/apps/morpho-supply/src/hooks/useMaxBorrowableAmount.ts
@@ -64,7 +64,8 @@ export const useMaxBorrowableAmount = () => {
   const marketBorrowLimit =
     market &&
     maxReallocatableLiquidity &&
-    (market as MorphoMarket).state.liquidityAssets + maxReallocatableLiquidity;
+    BigInt((market as MorphoMarket).state.liquidityAssets) +
+      maxReallocatableLiquidity;
 
   const canUserBorrowMaxMarket =
     maxBorrowableAmount &&

--- a/apps/morpho-supply/src/hooks/useMaxBorrowableAmount.ts
+++ b/apps/morpho-supply/src/hooks/useMaxBorrowableAmount.ts
@@ -1,0 +1,43 @@
+import { MarketUtils } from "@morpho-org/blue-sdk";
+import { useUserMarketPosition } from "./useUserMarketPosition";
+import { getMarketParams } from "#/utils/getMarketParams";
+import { useMemo } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
+import type { MorphoSupplyFormData } from "#/contexts/form";
+import type { MorphoMarket } from "@bleu/cow-hooks-ui";
+import { useReadPrice } from "./useReadPrice";
+
+export const useMaxBorrowableAmount = () => {
+  const { control } = useFormContext<MorphoSupplyFormData>();
+  const { market } = useWatch({ control });
+
+  const lltv =
+    market &&
+    (BigInt((market as MorphoMarket).lltv) * BigInt(9500)) / BigInt(10000);
+  const data = useUserMarketPosition({
+    marketKey: (market as MorphoMarket).uniqueKey,
+    marketParams: getMarketParams(market as MorphoMarket),
+  });
+
+  const price = useReadPrice();
+
+  const maxBorrowableAmount = useMemo(() => {
+    if (!data || !lltv) return;
+    const { totalBorrowAssets, totalBorrowShares, collateral, borrowShares } =
+      data;
+
+    return MarketUtils.getMaxBorrowableAssets(
+      { collateral, borrowShares },
+      {
+        totalBorrowAssets,
+        totalBorrowShares,
+        price,
+      },
+      {
+        lltv,
+      }
+    );
+  }, [data, lltv, price]);
+
+  return maxBorrowableAmount;
+};

--- a/apps/morpho-supply/src/hooks/useMaxBorrowableAmount.ts
+++ b/apps/morpho-supply/src/hooks/useMaxBorrowableAmount.ts
@@ -28,8 +28,7 @@ export const useMaxBorrowableAmount = () => {
       : BigInt(0);
 
   const lltv =
-    market &&
-    (BigInt((market as MorphoMarket).lltv) * BigInt(9500)) / BigInt(10000);
+    market && ((market as MorphoMarket).lltv * BigInt(9500)) / BigInt(10000);
   const data = useUserMarketPosition({
     marketKey: (market as MorphoMarket).uniqueKey,
     marketParams: getMarketParams(market as MorphoMarket),
@@ -64,8 +63,7 @@ export const useMaxBorrowableAmount = () => {
   const marketBorrowLimit =
     market &&
     maxReallocatableLiquidity &&
-    BigInt((market as MorphoMarket).state.liquidityAssets) +
-      maxReallocatableLiquidity;
+    (market as MorphoMarket).state.liquidityAssets + maxReallocatableLiquidity;
 
   const canUserBorrowMaxMarket =
     maxBorrowableAmount &&

--- a/apps/morpho-supply/src/hooks/useReadPrice.ts
+++ b/apps/morpho-supply/src/hooks/useReadPrice.ts
@@ -1,9 +1,9 @@
-import type { MorphoSupplyFormData } from "#/contexts/form";
 import { type MorphoMarket, useIFrameContext } from "@bleu/cow-hooks-ui";
 import { morphoOracleAbi } from "@bleu/utils/transactionFactory";
 import { useCallback } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 import useSWR from "swr";
+import type { MorphoSupplyFormData } from "#/contexts/form";
 
 export const useReadPrice = () => {
   const { control } = useFormContext<MorphoSupplyFormData>();

--- a/apps/morpho-supply/src/hooks/useReadPrice.ts
+++ b/apps/morpho-supply/src/hooks/useReadPrice.ts
@@ -1,0 +1,30 @@
+import type { MorphoSupplyFormData } from "#/contexts/form";
+import { type MorphoMarket, useIFrameContext } from "@bleu/cow-hooks-ui";
+import { morphoOracleAbi } from "@bleu/utils/transactionFactory";
+import { useCallback } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
+import useSWR from "swr";
+
+export const useReadPrice = () => {
+  const { control } = useFormContext<MorphoSupplyFormData>();
+  const { market } = useWatch({ control });
+
+  const { publicClient } = useIFrameContext();
+
+  const fetcher = useCallback(async () => {
+    if (!publicClient || !market) throw new Error("missing publicClient");
+    return await publicClient.readContract({
+      address: (market as MorphoMarket).oracle.address,
+      abi: morphoOracleAbi,
+      functionName: "price",
+    });
+  }, [publicClient, market]);
+
+  return useSWR([market], fetcher, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+    refreshWhenOffline: false,
+    refreshWhenHidden: false,
+    refreshInterval: 0,
+  }).data;
+};

--- a/apps/morpho-supply/src/utils/borrowReallocation.ts
+++ b/apps/morpho-supply/src/utils/borrowReallocation.ts
@@ -34,8 +34,7 @@ export function getMaxReallocatableLiquidity(
           .includes(vaultAddress),
       );
 
-    const liquidity =
-      BigInt(mkt.state.supplyAssets) - BigInt(mkt.state.borrowAssets);
+    const liquidity = mkt.state.supplyAssets - mkt.state.borrowAssets;
     maxReallocatableLiquidity += liquidity;
     return {
       marketKey: mkt.uniqueKey,
@@ -54,8 +53,7 @@ export function buildWithdrawals(
   maxReallocatableLiquidity: bigint,
   possibleWithdrawals: Withdrawal[],
 ) {
-  const marketLiquidity =
-    BigInt(market.state.supplyAssets) - BigInt(market.state.borrowAssets);
+  const marketLiquidity = market.state.supplyAssets - market.state.borrowAssets;
 
   if (amount > marketLiquidity + maxReallocatableLiquidity) return [];
   if (amount <= marketLiquidity) return [];

--- a/apps/morpho-supply/src/utils/decimalsToBigInt.ts
+++ b/apps/morpho-supply/src/utils/decimalsToBigInt.ts
@@ -3,7 +3,7 @@ import { parseUnits } from "viem";
 
 export function decimalsToBigInt(
   amount: string | undefined,
-  decimals: number | undefined
+  decimals: number | undefined,
 ) {
   if (amount === undefined || decimals === undefined) return;
 

--- a/apps/morpho-supply/src/utils/decimalsToBigInt.ts
+++ b/apps/morpho-supply/src/utils/decimalsToBigInt.ts
@@ -1,0 +1,11 @@
+import { BigNumber } from "ethers";
+import { parseUnits } from "viem";
+
+export function decimalsToBigInt(
+  amount: string | undefined,
+  decimals: number | undefined
+) {
+  if (amount === undefined || decimals === undefined) return;
+
+  return BigNumber.from(parseUnits(amount.toString(), decimals)).toBigInt();
+}

--- a/packages/cow-hooks-ui/src/hooks/useMorphoMarkets.ts
+++ b/packages/cow-hooks-ui/src/hooks/useMorphoMarkets.ts
@@ -4,6 +4,7 @@ import { gql } from "graphql-request";
 import useSWR from "swr";
 import type { Address } from "viem";
 import type { MarketPosition, MorphoMarket } from "../types";
+import { ensureBigIntType } from "../utils/ensureBigInt";
 
 interface IQuery {
   markets: {
@@ -168,13 +169,15 @@ export function useMorphoMarkets(
       ) as (MarketPosition & { uniqueKey: string })[];
 
       // merge positions into markets
-      const marketsWithPositions = markets.map((market) => {
-        const position = positions.find(
-          (position) => position.uniqueKey === market.uniqueKey,
-        );
-        if (!position) return { ...market, position: null };
-        return { ...market, position: position as MarketPosition };
-      });
+      const marketsWithPositions = ensureBigIntType(
+        markets.map((market) => {
+          const position = positions.find(
+            (position) => position.uniqueKey === market.uniqueKey,
+          );
+          if (!position) return { ...market, position: null };
+          return { ...market, position: position as MarketPosition };
+        }),
+      );
 
       return [
         ...marketsWithPositions.filter((m) => m.position),

--- a/packages/cow-hooks-ui/src/utils/ensureBigInt.ts
+++ b/packages/cow-hooks-ui/src/utils/ensureBigInt.ts
@@ -1,0 +1,73 @@
+import type { MorphoMarket } from "../types";
+
+/**
+ * Ensures all bigint fields in MorphoMarket objects are properly converted to bigint type
+ * @param markets Array of MorphoMarket objects
+ * @returns Array of MorphoMarket objects with all bigint fields guaranteed to be of bigint type
+ */
+export function ensureBigIntType(markets: MorphoMarket[]): MorphoMarket[] {
+  return markets.map((market) => {
+    // Create a deep copy to avoid modifying the original object
+    const newMarket = structuredClone(market);
+
+    // Convert fields in state
+    if (newMarket.state) {
+      newMarket.state.supplyAssets = ensureBigInt(newMarket.state.supplyAssets);
+      newMarket.state.borrowAssets = ensureBigInt(newMarket.state.borrowAssets);
+      newMarket.state.liquidityAssets = ensureBigInt(
+        newMarket.state.liquidityAssets,
+      );
+    }
+
+    // Convert lltv
+    newMarket.lltv = ensureBigInt(newMarket.lltv);
+
+    // Convert reallocatableLiquidityAssets
+    newMarket.reallocatableLiquidityAssets = ensureBigInt(
+      newMarket.reallocatableLiquidityAssets,
+    );
+
+    // Convert position fields if position exists
+    if (newMarket.position) {
+      newMarket.position.borrowAssets = ensureBigInt(
+        newMarket.position.borrowAssets,
+      );
+      newMarket.position.borrowShares = ensureBigInt(
+        newMarket.position.borrowShares,
+      );
+      newMarket.position.collateral = ensureBigInt(
+        newMarket.position.collateral,
+      );
+      newMarket.position.collateralValue = ensureBigInt(
+        newMarket.position.collateralValue,
+      );
+      newMarket.position.supplyAssets = ensureBigInt(
+        newMarket.position.supplyAssets,
+      );
+      newMarket.position.supplyShares = ensureBigInt(
+        newMarket.position.supplyShares,
+      );
+    }
+
+    return newMarket;
+  });
+}
+
+/**
+ * Helper function to ensure a value is of bigint type
+ * @param value Value to convert to bigint if it's not already
+ * @returns Value as bigint
+ */
+export function ensureBigInt(value: string | bigint | null | number): bigint {
+  if (typeof value === "bigint") {
+    return value;
+  }
+
+  // Handle null or undefined
+  if (value == null) {
+    return BigInt(0);
+  }
+
+  // For string, number, or any other type, convert to bigint
+  return BigInt(value);
+}

--- a/packages/utils/transactionFactory/abis/morphoOracleAbi.ts
+++ b/packages/utils/transactionFactory/abis/morphoOracleAbi.ts
@@ -1,0 +1,117 @@
+export const morphoOracleAbi = [
+  {
+    inputs: [
+      { internalType: "contract IERC4626", name: "vault", type: "address" },
+      {
+        internalType: "contract AggregatorV3Interface",
+        name: "baseFeed1",
+        type: "address",
+      },
+      {
+        internalType: "contract AggregatorV3Interface",
+        name: "baseFeed2",
+        type: "address",
+      },
+      {
+        internalType: "contract AggregatorV3Interface",
+        name: "quoteFeed1",
+        type: "address",
+      },
+      {
+        internalType: "contract AggregatorV3Interface",
+        name: "quoteFeed2",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "vaultConversionSample",
+        type: "uint256",
+      },
+      { internalType: "uint256", name: "baseTokenDecimals", type: "uint256" },
+      { internalType: "uint256", name: "quoteTokenDecimals", type: "uint256" },
+    ],
+    stateMutability: "nonpayable",
+    type: "constructor",
+  },
+  { inputs: [], name: "MathOverflowedMulDiv", type: "error" },
+  {
+    inputs: [],
+    name: "BASE_FEED_1",
+    outputs: [
+      {
+        internalType: "contract AggregatorV3Interface",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "BASE_FEED_2",
+    outputs: [
+      {
+        internalType: "contract AggregatorV3Interface",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "QUOTE_FEED_1",
+    outputs: [
+      {
+        internalType: "contract AggregatorV3Interface",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "QUOTE_FEED_2",
+    outputs: [
+      {
+        internalType: "contract AggregatorV3Interface",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "SCALE_FACTOR",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "VAULT",
+    outputs: [{ internalType: "contract IERC4626", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "VAULT_CONVERSION_SAMPLE",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "price",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;

--- a/packages/utils/transactionFactory/index.ts
+++ b/packages/utils/transactionFactory/index.ts
@@ -15,3 +15,4 @@ export * from "./abis/morphoVaultAbi";
 export * from "./abis/morphoAbi";
 export * from "./abis/morphoIrmAbi";
 export * from "./abis/morphoPublicAllocatorAbi";
+export * from "./abis/morphoOracleAbi";


### PR DESCRIPTION
This PR:
- Use same logic as morpho app for supply and borrow fields
- Create before / after display for: collateral, borrow, LTV
- Handle button error messages for errors: insufficient token balance. Insufficient supply.