### PR TITLE
fix(gas): bump hook gasLimit margin from 1.2x to 1.5x

### DIFF
--- a/packages/cow-hooks-ui/src/hooks/useSubmitHook.ts
+++ b/packages/cow-hooks-ui/src/hooks/useSubmitHook.ts
@@ -31,7 +31,7 @@ export function useSubmitHook({
       });
 
       const gasLimit = BigNumber.from(estimatedGas)
-        .mul(120)
+        .mul(150)
         .div(100)
         .toString();
 


### PR DESCRIPTION
## Summary

Bumps the safety margin applied to `eth_estimateGas` results from **1.2×** to **1.5×** in `packages/cow-hooks-ui/src/hooks/useSubmitHook.ts` — the shared spot used by every hook dapp (`withdraw-cow-amm`, `withdraw-uni-v2`, `claim-vesting`, `deposit-*`, etc.).

## Why

QA reported (Slack: Elena) that hooks "stopped being executed" on production. Investigation showed they **are** being submitted on-chain but reverting with out-of-gas inside the `HookTrampoline`, which silently swallows the revert by design — so the order shows `fulfilled` while the hook never actually runs.

### Evidence — same wallet, same `COW_AMM_WITHDRAW` flow on Arbitrum

| Date | Block | gasLimit (appData) | Actual used | Result |
|---|---|---:|---:|---|
| 13 May | 462,437,316 | 273,421 | 211,629 | ✅ |
| 19 May | 464,469,635 | 258,438 | 211,629 | ✅ |
| 16 Jun | 474,090,522 | 258,142 | >250,683 | ❌ OOG |

**Per-call delta (May → Jun):**
- `exitPool` (CoW AMM): **+44,500**
- `transferFrom` (USDT0 OFT): **+6,000**
- `_useNonce`: +2,000
- `authenticateHooks`: +2,500

Total: ~55k over the previous budget.

**Not a CoW-Shed upgrade.** EIP-1967 implementation slot on `COWShedFactory 0x79932c178ad3d0a4864b0322ce7a8405d74de290` is `0x2cffa8cf11b90c9f437567b86352169df4009f73` at every block from 13 May to today — unchanged. The extra cost is downstream:
- CoW AMM `DeployableVM` (`0x9585c3062df1c247d5e373cfca9167f7dc2b5963`)
- USDT0 OFT (`0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9`)

### Why 1.5× and not Elena's suggested +20%

The existing code **already** applies +20% on top of `eth_estimateGas`. Adding another +20% would compound to ~1.44×. Going to 1.5× directly:
- Covers the current +55k regression with ~80k headroom
- Protects against further bumps in USDT0/LayerZero or AMM-side state growth
- Single-character change in a shared file → all hook dapps benefit

`viem`'s `publicClient.estimateGas` keeps undershooting actual on-chain consumption (likely warm/cold state divergence between simulation and execution), so a margin >1.2× is justified independent of the regression.

## Failing transactions (for reference)

- `0x383f053ac1748f77ce54f9fbba668c7b633bba1ed10f4ac919dd9afd9a957771` (`UNI_V2_WITHDRAW`) — OOG at `USDT0.transfer → ArbitrumExtensionV2._transfer`
- `0x477d45250c165ab68af2c0c37708f874a47c2d01689905c5690acb0dc9721a72` (`COW_AMM_WITHDRAW`) — OOG at `DeployableVM.buildInputs`
- `0x274ce0d4fa1ca717d7b253ebd00d770c1ab7b4e98434f49f7edbfff229f3bc66` (`COW_AMM_WITHDRAW`) — same pattern

## Test plan

- [ ] Vercel preview deploys for all hook dapps
- [ ] Reproduce a `COW_AMM_WITHDRAW` on Arbitrum against the preview build — confirm appData `gasLimit` is now ~1.5× the estimate
- [ ] Settle a test order and confirm the hook actually executes (no `execution reverted` note inside `settle()`)
- [ ] Sanity-check `UNI_V2_WITHDRAW` on Arbitrum (USDT0 path)
- [ ] Spot-check other dapps (`claim-vesting`, `deposit-*`) for no regression on chains where gas was already comfortable

🤖 Generated with [Claude Code](https://claude.com/claude-code)