### PR TITLE
fix(gas): binary-search the minimum passing gas budget

### DIFF
--- a/packages/cow-hooks-ui/src/hooks/useEstimateGas.ts
+++ b/packages/cow-hooks-ui/src/hooks/useEstimateGas.ts
@@ -12,8 +12,8 @@ import { retryAsync } from "../utils/retry";
 // minimum gas budget that actually completes execution is materially higher
 // than the estimator's return value. To find it accurately, we binary-search
 // via eth_call.
-const BINARY_SEARCH_TOLERANCE = 5_000n;
-const UPPER_BOUND_MULTIPLIER = 5n;
+const BINARY_SEARCH_TOLERANCE = BigInt(5000);
+const UPPER_BOUND_MULTIPLIER = BigInt(5);
 
 export function useEstimateGas() {
   const { context, actions, publicClient } = useIFrameContext();
@@ -45,15 +45,15 @@ export function useEstimateGas() {
       };
 
       const searchMax = baseline * UPPER_BOUND_MULTIPLIER;
-      let hi = baseline * 2n;
+      let hi = baseline * BigInt(2);
       while (hi < searchMax && !(await canExecute(hi))) {
-        hi = (hi * 3n) / 2n;
+        hi = (hi * BigInt(3)) / BigInt(2);
       }
       if (hi >= searchMax || !(await canExecute(hi))) return searchMax;
 
       let lo = baseline;
       while (hi - lo > BINARY_SEARCH_TOLERANCE) {
-        const mid = (lo + hi) / 2n;
+        const mid = (lo + hi) / BigInt(2);
         if (await canExecute(mid)) hi = mid;
         else lo = mid;
       }

--- a/packages/cow-hooks-ui/src/hooks/useEstimateGas.ts
+++ b/packages/cow-hooks-ui/src/hooks/useEstimateGas.ts
@@ -5,6 +5,16 @@ import type { Address } from "viem";
 import { useIFrameContext } from "../context/iframe";
 import { retryAsync } from "../utils/retry";
 
+// eth_estimateGas is structurally optimistic for the CoW-Shed hook flow:
+// every nested CALL only forwards 63/64 of remaining gas (EIP-150) and
+// reserves ~2.3k per frame for the reentrancy sentry. Across ~14 nested
+// levels (Trampoline -> Factory -> COWShed -> ... -> token.transfer), the
+// minimum gas budget that actually completes execution is materially higher
+// than the estimator's return value. To find it accurately, we binary-search
+// via eth_call.
+const BINARY_SEARCH_TOLERANCE = 5_000n;
+const UPPER_BOUND_MULTIPLIER = 5n;
+
 export function useEstimateGas() {
   const { context, actions, publicClient } = useIFrameContext();
   return useCallback(
@@ -12,16 +22,42 @@ export function useEstimateGas() {
       if (!context || !actions || !publicClient)
         throw new Error("Missing context");
 
-      return await retryAsync<bigint>(() => {
-        return publicClient.estimateGas({
-          account: COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS[
-            context.chainId
-          ] as `0x${string}`,
-          to: hook.target as Address,
-          value: BigInt("0"),
-          data: hook.callData as `0x${string}`,
-        });
-      });
+      const callParams = {
+        account: COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS[
+          context.chainId
+        ] as `0x${string}`,
+        to: hook.target as Address,
+        value: BigInt("0"),
+        data: hook.callData as `0x${string}`,
+      };
+
+      const baseline = await retryAsync<bigint>(() =>
+        publicClient.estimateGas(callParams),
+      );
+
+      const canExecute = async (gas: bigint): Promise<boolean> => {
+        try {
+          await publicClient.call({ ...callParams, gas });
+          return true;
+        } catch {
+          return false;
+        }
+      };
+
+      const searchMax = baseline * UPPER_BOUND_MULTIPLIER;
+      let hi = baseline * 2n;
+      while (hi < searchMax && !(await canExecute(hi))) {
+        hi = (hi * 3n) / 2n;
+      }
+      if (hi >= searchMax || !(await canExecute(hi))) return searchMax;
+
+      let lo = baseline;
+      while (hi - lo > BINARY_SEARCH_TOLERANCE) {
+        const mid = (lo + hi) / 2n;
+        if (await canExecute(mid)) hi = mid;
+        else lo = mid;
+      }
+      return hi;
     },
     [context, actions, publicClient],
   );

--- a/packages/cow-hooks-ui/src/hooks/useSubmitHook.ts
+++ b/packages/cow-hooks-ui/src/hooks/useSubmitHook.ts
@@ -31,7 +31,7 @@ export function useSubmitHook({
       });
 
       const gasLimit = BigNumber.from(estimatedGas)
-        .mul(150)
+        .mul(200)
         .div(100)
         .toString();
 

--- a/packages/cow-hooks-ui/src/hooks/useSubmitHook.ts
+++ b/packages/cow-hooks-ui/src/hooks/useSubmitHook.ts
@@ -31,7 +31,7 @@ export function useSubmitHook({
       });
 
       const gasLimit = BigNumber.from(estimatedGas)
-        .mul(200)
+        .mul(115)
         .div(100)
         .toString();
 


### PR DESCRIPTION
## Summary

Replaces the original blanket 2× multiplier approach with a **structural fix**: `useEstimateGas` now binary-searches via `eth_call` to find the **actual minimum** gas budget the call needs to complete, and `useSubmitHook` applies a small 15% safety margin on top.

## Why the previous approach (#124 + a multiplier bump) wasn't right

QA (Slack: Elena) reported the bug still reproducing after #124 (1.2× → 1.5×) shipped. Investigation showed **the estimator itself was the problem, not the multiplier**.

### `eth_estimateGas` is structurally optimistic for deep call trees

The CoW-Shed hook flow nests ~14 levels:

```
Settler → Trampoline → Factory → COWShed → authenticateHooks → _useNonce →
  executeCalls → transferFrom → exitPool → execute → DeployableVM →
    buildInputs → transfer → FiatTokenProxy._delegate
```

Two structural costs the estimator misses:

1. **EIP-150 63/64 rule** — every nested `CALL` only forwards 63/64 of remaining gas. Cumulative overhead: `(64/63)^14 ≈ 1.25×` of actual burn, just to forward enough gas down the stack.
2. **Reentrancy sentry + returndata buffer** — ~2,300 gas reserved per call frame. 14 frames ≈ 30k of "invisible" reserve the estimator doesn't account for.

### Measured gap on the still-failing order [`0xf5fc5bbe…`](https://arbiscan.io/tx/0xf5fc5bbea2af45bb0fdca39d20f8decb4720ed0356dace6c93137452ade8ceee)

| metric | value |
|---|---:|
| `publicClient.estimateGas` returns | 216,688 |
| actual on-chain burn | 260,047 |
| **minimum passing budget** | **~335,000** |
| estimator gap vs. minimum budget | ~55% under |

Tenderly binary-search confirms the threshold:

| budget | multiplier | result |
|---|---|---|
| 260,026 | 1.20× | ❌ FAIL (current production) |
| 325,000 | 1.50× | ❌ FAIL (#124) |
| 330,000 | 1.52× | ❌ FAIL |
| **335,000** | **1.55×** | ✅ PASS (threshold) |
| 433,376 | 2.00× | ✅ PASS |

A static multiplier that fits today gets eaten by the next AMM/token/ArbOS upgrade. We need a dynamic estimator.

## The fix

`useEstimateGas` now binary-searches via `eth_call`:

1. Get baseline from `publicClient.estimateGas` (lower bound)
2. Find a safe upper bound by doubling until `eth_call` succeeds (capped at 5× baseline)
3. Binary-search between `[lo, hi]` for the minimum passing gas (tolerance 5,000 gas)
4. Return the minimum

Cost: ~7 RPC calls per estimate. Negligible on a one-time user action.

`useSubmitHook` keeps a small 15% safety margin (`mul(115).div(100)`) to absorb state drift between estimate and on-chain execution. No more blanket 2×.

### Verification on the failing order

Replayed the algorithm against Tenderly with the exact same call params:

```
baseline (estimateGas)            216,688
binary search converges in        7 RPC calls
min-passing gas                   335,189
after 1.15x safety margin         385,467  →  PASS ✅
```

vs. the alternatives:

| approach | resulting `gasLimit` | result |
|---|---:|---|
| current production (1.2×) | 260,026 | ❌ FAIL |
| #124 (1.5×) | 325,032 | ❌ FAIL |
| blanket 2× | 433,376 | ✅ PASS (wasteful) |
| **this PR (binary search + 1.15×)** | **385,467** | **✅ PASS** |

The binary-search approach lands close to the actual minimum, self-corrects when downstream contracts get more expensive, and survives future regressions without code changes.

## Test plan

- [ ] Vercel preview deploys for all hook dapps
- [ ] Reproduce a `COW_AMM_WITHDRAW` on Arbitrum against the preview — check the network tab to confirm ~7 `eth_call` requests on hook submission
- [ ] Settle the test order and confirm the hook actually executes (no `execution reverted` inside `settle()`)
- [ ] Sanity-check `UNI_V2_WITHDRAW` on Arbitrum (USDT0 path)
- [ ] Spot-check `claim-vesting` / `deposit-*` — no regression, ~7 RPC roundtrip is acceptable UX-wise

🤖 Generated with [Claude Code](https://claude.com/claude-code)