### PR TITLE
fix(gas): 2x margin + COWShed first-time deploy buffer

### DIFF
--- a/packages/cow-hooks-ui/src/hooks/useEstimateGas.ts
+++ b/packages/cow-hooks-ui/src/hooks/useEstimateGas.ts
@@ -5,24 +5,38 @@ import type { Address } from "viem";
 import { useIFrameContext } from "../context/iframe";
 import { retryAsync } from "../utils/retry";
 
+// First-time COWShed proxy deployment (CREATE2 + storage init via
+// COWShedFactory._initializeProxy) consumes ~247k gas that
+// eth_estimateGas systematically undershoots. Padded to 300k to absorb
+// state variance and minor future contract changes. Measured against
+// Arbitrum tx 0xed5e611659a7461a9c5aeb4c072de45e4b11427d3581d251a208a6c9b1c28534.
+const COW_SHED_DEPLOY_GAS_BUFFER = BigInt(300_000);
+
 export function useEstimateGas() {
-  const { context, actions, publicClient } = useIFrameContext();
+  const { context, actions, publicClient, cowShedProxy } = useIFrameContext();
   return useCallback(
     async (hook: Omit<CowHook, "gasLimit" | "dappId">) => {
       if (!context || !actions || !publicClient)
         throw new Error("Missing context");
 
-      return await retryAsync<bigint>(() => {
-        return publicClient.estimateGas({
+      const baseline = await retryAsync<bigint>(() =>
+        publicClient.estimateGas({
           account: COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS[
             context.chainId
           ] as `0x${string}`,
           to: hook.target as Address,
           value: BigInt("0"),
           data: hook.callData as `0x${string}`,
-        });
-      });
+        }),
+      );
+
+      if (!cowShedProxy) return baseline + COW_SHED_DEPLOY_GAS_BUFFER;
+      const code = await publicClient
+        .getBytecode({ address: cowShedProxy })
+        .catch(() => undefined);
+      const needsDeploy = !code || code === "0x";
+      return needsDeploy ? baseline + COW_SHED_DEPLOY_GAS_BUFFER : baseline;
     },
-    [context, actions, publicClient],
+    [context, actions, publicClient, cowShedProxy],
   );
 }

--- a/packages/cow-hooks-ui/src/hooks/useEstimateGas.ts
+++ b/packages/cow-hooks-ui/src/hooks/useEstimateGas.ts
@@ -5,16 +5,6 @@ import type { Address } from "viem";
 import { useIFrameContext } from "../context/iframe";
 import { retryAsync } from "../utils/retry";
 
-// eth_estimateGas is structurally optimistic for the CoW-Shed hook flow:
-// every nested CALL only forwards 63/64 of remaining gas (EIP-150) and
-// reserves ~2.3k per frame for the reentrancy sentry. Across ~14 nested
-// levels (Trampoline -> Factory -> COWShed -> ... -> token.transfer), the
-// minimum gas budget that actually completes execution is materially higher
-// than the estimator's return value. To find it accurately, we binary-search
-// via eth_call.
-const BINARY_SEARCH_TOLERANCE = BigInt(5000);
-const UPPER_BOUND_MULTIPLIER = BigInt(5);
-
 export function useEstimateGas() {
   const { context, actions, publicClient } = useIFrameContext();
   return useCallback(
@@ -22,42 +12,16 @@ export function useEstimateGas() {
       if (!context || !actions || !publicClient)
         throw new Error("Missing context");
 
-      const callParams = {
-        account: COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS[
-          context.chainId
-        ] as `0x${string}`,
-        to: hook.target as Address,
-        value: BigInt("0"),
-        data: hook.callData as `0x${string}`,
-      };
-
-      const baseline = await retryAsync<bigint>(() =>
-        publicClient.estimateGas(callParams),
-      );
-
-      const canExecute = async (gas: bigint): Promise<boolean> => {
-        try {
-          await publicClient.call({ ...callParams, gas });
-          return true;
-        } catch {
-          return false;
-        }
-      };
-
-      const searchMax = baseline * UPPER_BOUND_MULTIPLIER;
-      let hi = baseline * BigInt(2);
-      while (hi < searchMax && !(await canExecute(hi))) {
-        hi = (hi * BigInt(3)) / BigInt(2);
-      }
-      if (hi >= searchMax || !(await canExecute(hi))) return searchMax;
-
-      let lo = baseline;
-      while (hi - lo > BINARY_SEARCH_TOLERANCE) {
-        const mid = (lo + hi) / BigInt(2);
-        if (await canExecute(mid)) hi = mid;
-        else lo = mid;
-      }
-      return hi;
+      return await retryAsync<bigint>(() => {
+        return publicClient.estimateGas({
+          account: COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS[
+            context.chainId
+          ] as `0x${string}`,
+          to: hook.target as Address,
+          value: BigInt("0"),
+          data: hook.callData as `0x${string}`,
+        });
+      });
     },
     [context, actions, publicClient],
   );

--- a/packages/cow-hooks-ui/src/hooks/useSubmitHook.ts
+++ b/packages/cow-hooks-ui/src/hooks/useSubmitHook.ts
@@ -31,7 +31,7 @@ export function useSubmitHook({
       });
 
       const gasLimit = BigNumber.from(estimatedGas)
-        .mul(115)
+        .mul(200)
         .div(100)
         .toString();
 


### PR DESCRIPTION
## Summary

Replaces #125's binary-search approach with a structural fix split into two parts:

1. **`useSubmitHook`** keeps a static **2× margin** on `publicClient.estimateGas` (was 1.5× in #125, then 1.15× after the binary-search experiment).
2. **`useEstimateGas`** detects whether the user's COWShed proxy is deployed and **adds a fixed 300k buffer** to the estimate when it is not. eth_estimateGas systematically undershoots in the first-time-deploy case because `COWShedFactory._initializeProxy` (CREATE2 + storage init) consumes ~247k gas that the estimator misses.

## Evidence

### Repeat user (Elena, COWShed already deployed)

| approach | gasLimit | Tenderly result |
|---|---:|---|
| 1.2× (original) | 260,026 | ❌ FAIL |
| 1.5× (PR #124) | 325,032 | ❌ FAIL |
| binary search + 1.15× | 278,172 | ❌ FAIL |
| 2.0× (PR #125 / first version of this PR) | 482,000 | ✅ PASS |
| **this PR (no deploy needed → no buffer → 2×)** | **433,376** | ✅ **PASS** |

### First-time user (Bruno, COWShed NOT deployed)

Real on-chain test: order [`0x17ee9cdf…`](https://explorer.cow.fi/arb1/orders/0x17ee9cdf1031c382e460642d43bd637a30abcc2b5228e7d5d858b43853d12954c621c5a6c8f2ee120c11f1bd016029adbddf54cf6a32b590) settled on tx [`0xed5e6116…`](https://arbiscan.io/tx/0xed5e611659a7461a9c5aeb4c072de45e4b11427d3581d251a208a6c9b1c28534)

| approach | gasLimit | Tenderly result |
|---|---:|---|
| 2.0× alone | 505,649 | ❌ FAIL (used 497k, OOG at FiatTokenProxy._delegate) |
| 2.4× alone | 600,000 | ✅ PASS |
| 3.0× alone | 759,000 | ✅ PASS but wasteful for repeat users (no deploy = unneeded headroom) |
| **this PR (deploy needed → +300k buffer → 2× of adjusted)** | **1,105,648** | ✅ **PASS** |

## Why detect-and-buffer instead of a flat higher multiplier

A flat 3× would work for both cases but at the cost of giving repeat users ~720k of `gasLimit` for a real burn of ~260k — wasteful (cap, not charge, but still aesthetic and could spook unfamiliar reviewers).

This PR:
- Documents the WHY in code — `COW_SHED_DEPLOY_GAS_BUFFER = 300_000` is empirically measured, not magic
- Keeps the repeat-user `gasLimit` at the same level as PR #125 (~433k vs current ~260k)
- Covers first-time users with a clearly named, scenario-specific buffer
- Costs one extra `eth_getCode` per estimate (fallback to assume-deploy on RPC error)

## Why 300k buffer

- Measured deploy cost: **247,531 gas** (`COWShedFactory._initializeProxy` in the failed tx)
- Padded with ~50k for state variance and absorbing future contract changes
- Same buffer applies on all chains because the COWShed code is the same everywhere

## Test plan

- [x] Local typecheck (`pnpm --filter @bleu/cow-hooks-ui exec tsc --noEmit`) — clean
- [x] Local build (`pnpm --filter @bleu/withdraw-cow-amm build`) — clean
- [x] Tenderly simulation of both Elena's (repeat) and Bruno's (first-time) failing orders — both PASS
- [ ] Vercel preview deploys for all hook dapps
- [ ] Real on-chain test against preview: place a `COW_AMM_WITHDRAW` from a wallet that has never used cow-shed before, confirm hook executes (no `execution reverted` inside settle)
- [ ] Sanity-check `UNI_V2_WITHDRAW` on Arbitrum (same logic applies — flow goes through COWShed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)